### PR TITLE
ci(codeql): switch to reusable phenoShared workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,21 +4,17 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
   schedule:
-    - cron: '0 12 * * 1'
+    - cron: '17 4 * * 1'
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    uses: KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce629168f0e1ec3699706cb73d1f77cb751
     permissions:
+      contents: read
+      actions: read
       security-events: write
-    strategy:
-      matrix:
-        language: [rust]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+    with:
+      languages: '["rust"]'
+      build-mode: 'autobuild'


### PR DESCRIPTION
## **User description**
Swaps per-repo CodeQL workflow for a thin caller to `KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce629168f0e1ec3699706cb73d1f77cb751`.

Inputs: languages=`["rust"]`, build-mode=`autobuild`.

Depends on phenoShared#87. Caller is pinned to commit SHA; rebase after phenoShared#87 merges to point at main.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because security scanning is now delegated to an external reusable workflow, so changes in that workflow (despite SHA pinning) and permission/input mismatches could impact coverage or execution.
> 
> **Overview**
> Switches the CodeQL GitHub Action from an in-repo job definition to a thin caller that `uses` the pinned reusable workflow `KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce6`.
> 
> Tightens job permissions (adds `contents: read` and `actions: read`), explicitly passes `languages: '["rust"]'` and `build-mode: 'autobuild'`, and adjusts triggers (adds `pull_request` branch filter for `main` and changes the weekly cron schedule).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8f7cd25bafcc3882e61fb8080921d876e83e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Move CodeQL scanning to a shared workflow**

### What Changed
- CodeQL now runs through a shared reusable workflow instead of a repo-specific job setup
- The scan remains focused on Rust and still uses autobuild
- Pull requests to `main` are now scanned, and the weekly scan time has changed

### Impact
`✅ Consistent security scans across repos`
`✅ Fewer CodeQL setup issues`
`✅ Ongoing scan coverage for main branch changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=zFzPJfF_hAqE-yfK9jOKNucADUEIzCOOFD2iHFakVCc&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
