### PR TITLE
ci(deploy): switch to reusable VitePress pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,50 +8,12 @@ on:
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: agileplus-vitepress-pages
-  cancel-in-progress: false
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Install dependencies
-        working-directory: docs
-        run: bun install
-
-      - name: Build VitePress site
-        working-directory: docs
-        run: bun run docs:build
-        env:
-          GITHUB_PAGES: "true"
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: docs/.vitepress/dist
-
   deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    uses: KooshaPari/phenoShared/.github/workflows/reusable/vitepress-pages.yml@bda2ba0ab5abefd0abb0d29874379049786aaf0f
+    with:
+      concurrency_group: pheno-vitepress-pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write


### PR DESCRIPTION
## **User description**
Delegates to KooshaPari/phenoShared reusable VitePress pages workflow pinned at `bda2ba0ab5abefd0abb0d29874379049786aaf0f`. Part of cross-repo dedup (4→1 consolidation, ~715 bytes saved per repo).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Pages deployment pipeline by replacing in-repo build/deploy steps with an external reusable workflow, which could impact docs build or deployment behavior if the shared workflow differs or changes.
> 
> **Overview**
> Delegates the VitePress GitHub Pages pipeline to a pinned reusable workflow (`KooshaPari/phenoShared/.github/workflows/reusable/vitepress-pages.yml@bda2ba0…`) instead of running local `checkout`/Bun install/build/upload/deploy steps.
> 
> Removes the separate `build` job and in-file `concurrency` config, passing a `concurrency_group` input and keeping required `pages`/`id-token` permissions on the single `deploy` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13021529bedb64d96378435c10d3ee2358dddcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Move VitePress site deployment to a shared workflow**

### What Changed
- The docs site now deploys through a shared reusable GitHub Pages workflow instead of a local build-and-deploy job
- Deploys still run from `main` when docs or the deployment workflow change, with the same Pages access needed for publishing
- The workflow now uses a shared concurrency setup to avoid overlapping deployments

### Impact
`✅ Fewer docs deployment failures`
`✅ Consistent GitHub Pages publishes`
`✅ Safer one-at-a-time site updates`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=AORtE_devnXGqb7xRFv90wEhYlGOoPjZzmT6dzotcdc&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
