### PR TITLE
chore(ci): pin floating external actions to SHAs (sast-full.yml)

### DIFF
--- a/.github/workflows/sast-full.yml
+++ b/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # was: @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@3fc0c2aa6648d54242e4af6fbfde0701796e4fb0  # was: @main
         with:
           path: ./
           extra_args: --only-verified --fail


### PR DESCRIPTION
Replaces floating external action refs in `.github/workflows/sast-full.yml` with immutable commit SHAs.

Refs replaced: aquasecurity/trivy-action@master, trufflesecurity/trufflehog@main

Tag-pinned and internal KooshaPari refs are untouched.

Generated by API-only pin-hygiene audit.