### PR TITLE
fix(deps): bump rustls-webpki + thin-vec — close 4 CVEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2978,9 +2978,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
## Summary

Direct Cargo.lock edit (same pattern as helios-cli PR #526) to close 4 RUSTSEC advisories surfaced in `repos/docs/governance/org-cargo-audit-2026-04-25.md`:

| Crate | Before | After | Advisories |
|-------|--------|-------|------------|
| rustls-webpki | 0.103.10 | 0.103.13 | RUSTSEC-2026-0104 (HIGH), -0098 (MED), -0099 (MED) |
| thin-vec | 0.2.14 | 0.2.16 | RUSTSEC-2026-0103 (HIGH) |

`cargo audit` before: **4 vulns** (1 HIGH UAF/double-free + 1 HIGH TLS-panic + 2 MED) -> after: **0 vulns**.

No manifest changes; transitively pulled bumps only.

## Test plan

- [x] `cargo audit --file Cargo.lock` reports 0 vulnerabilities
- [ ] Workspace builds (deferred — disk-budget; see audit doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since changes are lockfile-only dependency version bumps, but they affect TLS/cert verification and a core collection type so runtime behavior/regressions are possible if downstream code relies on prior crate behavior.
> 
> **Overview**
> Updates `Cargo.lock` to bump transitive dependencies `rustls-webpki` from `0.103.10` to `0.103.13` and `thin-vec` from `0.2.14` to `0.2.16` (with new checksums).
> 
> No manifests or source code change; this is a lockfile-only update intended to pick up security fixes in those crates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea6f7e31c8212caeb8a4c475552ff0e8bf3325e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->