### PR TITLE
docs(crates): point Phase 1 crate copies to phenoShared canonical

### DIFF
--- a/crates/phenotype-config-core/CANONICAL.md
+++ b/crates/phenotype-config-core/CANONICAL.md
@@ -1,0 +1,18 @@
+# Canonical Source Notice
+
+**This crate has been promoted to the `phenoShared` workspace.**
+
+The canonical source for `phenotype-config-core` now lives at:
+
+- Repository: https://github.com/KooshaPari/phenoShared
+- Path: https://github.com/KooshaPari/phenoShared/tree/main/crates/phenotype-config-core
+
+## Status
+
+The copy in this repository (`pheno/crates/phenotype-config-core/`) is **deprecated** and retained only for backward compatibility with existing path-based consumers. No new feature work should land here.
+
+## Migration Guidance
+
+New consumers should depend on the `phenoShared` version. Existing consumers will be migrated forward-only as part of the Phase 2 reuse rollout (see `phenoShared` PR #102 and follow-up tracking).
+
+Do **not** edit this copy for non-trivial changes — open the change against `phenoShared` instead, then re-sync.

--- a/crates/phenotype-error-core/CANONICAL.md
+++ b/crates/phenotype-error-core/CANONICAL.md
@@ -1,0 +1,18 @@
+# Canonical Source Notice
+
+**This crate has been promoted to the `phenoShared` workspace.**
+
+The canonical source for `phenotype-error-core` now lives at:
+
+- Repository: https://github.com/KooshaPari/phenoShared
+- Path: https://github.com/KooshaPari/phenoShared/tree/main/crates/phenotype-error-core
+
+## Status
+
+The copy in this repository (`pheno/crates/phenotype-error-core/`) is **deprecated** and retained only for backward compatibility with existing path-based consumers. No new feature work should land here.
+
+## Migration Guidance
+
+New consumers should depend on the `phenoShared` version. Existing consumers will be migrated forward-only as part of the Phase 2 reuse rollout (see `phenoShared` PR #102 and follow-up tracking).
+
+Do **not** edit this copy for non-trivial changes — open the change against `phenoShared` instead, then re-sync.

--- a/crates/phenotype-health/CANONICAL.md
+++ b/crates/phenotype-health/CANONICAL.md
@@ -1,0 +1,18 @@
+# Canonical Source Notice
+
+**This crate has been promoted to the `phenoShared` workspace.**
+
+The canonical source for `phenotype-health` now lives at:
+
+- Repository: https://github.com/KooshaPari/phenoShared
+- Path: https://github.com/KooshaPari/phenoShared/tree/main/crates/phenotype-health
+
+## Status
+
+The copy in this repository (`pheno/crates/phenotype-health/`) is **deprecated** and retained only for backward compatibility with existing path-based consumers. No new feature work should land here.
+
+## Migration Guidance
+
+New consumers should depend on the `phenoShared` version. Existing consumers will be migrated forward-only as part of the Phase 2 reuse rollout (see `phenoShared` PR #102 and follow-up tracking).
+
+Do **not** edit this copy for non-trivial changes — open the change against `phenoShared` instead, then re-sync.


### PR DESCRIPTION
## **User description**
## Summary
- Adds `CANONICAL.md` to `phenotype-error-core`, `phenotype-config-core`, and `phenotype-health` pointing consumers to the canonical `phenoShared` workspace (PR #102).
- Docs-only change — no code or `Cargo.toml` modifications. Existing path-based consumers continue to work unchanged.
- Forward-only migration of consumers will land separately as part of Phase 2 reuse rollout.

## Test plan
- [x] No code changes; docs-only.
- [ ] Spot-check rendered Markdown links to phenoShared resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds guidance files; no code, build, or dependency behavior is modified.
> 
> **Overview**
> Adds `CANONICAL.md` notices to `phenotype-config-core`, `phenotype-error-core`, and `phenotype-health` marking the in-repo copies as *deprecated* and pointing contributors/consumers to the canonical `phenoShared` locations.
> 
> Includes migration guidance to avoid landing non-trivial changes in this repo and to move new consumption to `phenoShared`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81f484e3696d3c3dd7ad052ee508340fb18dae47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Point the Phase 1 crate copies to their canonical home in phenoShared**

### What Changed
- Added a clear notice in `phenotype-error-core`, `phenotype-config-core`, and `phenotype-health` that these copies are deprecated
- Each notice points readers to the canonical crate location in the `phenoShared` repository
- The docs tell consumers to use `phenoShared` for new work and keep these copies only for backward compatibility

### Impact
`✅ Clearer crate ownership`
`✅ Fewer new changes made in deprecated copies`
`✅ Smoother Phase 2 migration guidance`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5F76d9AzXo4UWSc0mKUDuCE5QdbudsJCg-oxYZ7jYzU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
