### PR TITLE
fix(deps): replace cross-repo path leak for phenotype-observability

### DIFF
--- a/crates/phenotype-cache-adapter/Cargo.toml
+++ b/crates/phenotype-cache-adapter/Cargo.toml
@@ -15,7 +15,7 @@ lru = "0.12"
 dashmap = "5"
 tokio = { version = "1", features = ["sync", "rt"] }
 tracing = "0.1"
-phenotype-observability = { path = "../../libs/phenotype-observability" }
+phenotype-observability = { git = "https://github.com/KooshaPari/PhenoProc.git", branch = "main" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Mirrors DataKit#18. Replaces `../../libs/phenotype-observability` path with git dep to PhenoProc (canonical home).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency source change; main impact is build/reproducibility if the `main` branch changes or the repo is unavailable.
> 
> **Overview**
> Replaces `phenotype-observability` in `crates/phenotype-cache-adapter/Cargo.toml` from a relative path (`../../libs/phenotype-observability`) to a git dependency (`KooshaPari/PhenoProc` on `main`) to avoid cross-repo path coupling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d61dc664cecdb64b79ae8a00d186af3fe1a2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->