### PR TITLE
Restore phenoShared workflow pins to @main

### DIFF
--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   sync:
-    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
+    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@main
     with:
       auto-label: auto-alert-sync

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
+    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@main
     with:
       concurrency_group: pheno-vitepress-pages
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release-drafter:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
+    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   guard:
-    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
+    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@main

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   gate:
-    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
+    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@main

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
     permissions:
       contents: write


### PR DESCRIPTION
## **User description**
Restore pinned phenoShared workflow callers to @main in the six workflow files requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching reusable workflow callers from a pinned commit SHA to `@main` increases supply-chain/behavior-change risk because future upstream changes can affect this repo’s CI/CD without a local code change.
> 
> **Overview**
> Updates six GitHub Actions workflow callers to reference `KooshaPari/phenoShared` reusable workflows via `@main` instead of a pinned commit SHA (alert sync, VitePress deploy, release drafter, security hook audit, self-merge gate, and tag automation). This makes CI/CD behavior track the latest upstream workflow changes automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27101b5e5273d37fc6bb5f45b8a3940ccb3d3f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Point GitHub workflows to the latest shared automation**

### What Changed
- The release, deploy, alert sync, security audit, self-merge gate, and tag automation workflows now use the latest shared workflow version from `main`
- CI and release automation will pick up upstream shared workflow updates without waiting for this repo to change

### Impact
`✅ Faster rollout of shared workflow fixes`
`✅ Less manual upkeep for CI and release automation`
`✅ Upstream workflow changes take effect sooner`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=6uGrCjjaakWnNQs0LwXQf9_-YZiyk7MGF-lrO5N87iI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
