### PR TITLE
ci(codeql): add Rust CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-rust.yml
+++ b/.github/workflows/codeql-rust.yml
@@ -1,0 +1,33 @@
+name: CodeQL (Rust)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 2'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"


### PR DESCRIPTION
Per memory feedback_codeql_no_rust_default_setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds an additional CodeQL workflow; primary impact is potentially increased CI runtime/noise from an extra analysis run.
> 
> **Overview**
> Adds a dedicated GitHub Actions workflow (`.github/workflows/codeql-rust.yml`) to run **CodeQL analysis for Rust** on pushes/PRs to `main`, on a weekly schedule, and via manual dispatch.
> 
> The workflow checks out the repo, initializes CodeQL for `rust`, runs `autobuild`, and uploads results to `security-events` with a Rust-specific category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7537ddcd00dfbee890f8282346062d1202bbbb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->