### PR TITLE
ci: fix policy gate PR head check

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -23,12 +23,14 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
 
           echo "HEAD_REF=$HEAD_REF"
           echo "BASE_REF=$BASE_REF"
+          echo "PR_HEAD_SHA=$PR_HEAD_SHA"
           echo "PR_LABELS=$PR_LABELS"
 
           if [[ "$HEAD_REF" == fix/* ]]; then
@@ -42,7 +44,7 @@ jobs:
           fi
 
           git fetch origin "$BASE_REF" --depth=100 || true
-          MERGES=$(git rev-list --merges "origin/$BASE_REF..HEAD" || true)
+          MERGES=$(git rev-list --merges "origin/$BASE_REF..$PR_HEAD_SHA" || true)
           if [[ -n "$MERGES" ]]; then
             echo "ERROR: merge commits detected in PR diff range:"
             echo "$MERGES"


### PR DESCRIPTION
## **User description**
## Summary
- use the pull request head SHA for merge-commit detection
- avoid flagging GitHub's synthetic pull_request merge checkout as a user merge commit

## Validation
- actionlint .github/workflows/policy-gate.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it narrows merge-commit detection to the real PR commit range to avoid false positives from GitHub’s synthetic merge ref.
> 
> **Overview**
> Updates the `Policy Gate` GitHub Actions workflow to pass and log `PR_HEAD_SHA` and use it for `git rev-list --merges origin/$BASE_REF..$PR_HEAD_SHA` instead of comparing against `HEAD`.
> 
> This avoids incorrectly flagging merge commits introduced by GitHub’s pull request checkout behavior while keeping the existing layered-branch enforcement intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f90d4d888526197a4b38c7803c1cbccc771d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Check the real pull request commit when enforcing merge-commit rules**

### What Changed
- The policy check now reviews the actual pull request head commit instead of GitHub’s synthetic merge checkout
- This stops valid pull requests from being flagged as containing merge commits because of the checkout style used by GitHub Actions
- The workflow also logs the pull request head SHA for clearer run output

### Impact
`✅ Fewer false policy failures`
`✅ Clearer CI checks for pull requests`
`✅ Less confusion from GitHub Actions merge checkouts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=vlXZJmouYsNCe4HYh86ym9mIY4aoF_qLI9Q4S6jA24U&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
