### PR TITLE
chore(deps): patch Rust advisory lock entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,9 +1052,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1084,9 +1084,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -1476,9 +1476,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
## Summary
- update Cargo.lock entries for openssl to 0.10.78
- update Cargo.lock entry for openssl-sys to 0.9.114
- update Cargo.lock entry for rand to 0.8.6

## Validation
- cargo audit --no-fetch
- git diff --check

## Notes
- Full cargo update/cargo tree is currently blocked by the PhenoProc git dependency failing to fetch submodule crates/cryptora because no URL is configured upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bumps (`openssl`/`openssl-sys` and `rand`) with no source changes; primary risk is potential build/compatibility issues from updated native OpenSSL bindings.
> 
> **Overview**
> Updates `Cargo.lock` to pick up patched dependency versions: `openssl` `0.10.76`→`0.10.78`, `openssl-sys` `0.9.112`→`0.9.114`, and `rand` `0.8.5`→`0.8.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161044fda2de8c8f04ba9b2d19bad3ea5a103e08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->