### PR TITLE
ci(pheno): stabilize SAST quick checks

### DIFF
--- a/.github/workflows/sast-quick.yml
+++ b/.github/workflows/sast-quick.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+        continue-on-error: true
 
   secrets:
     name: Secret Scanning
@@ -65,5 +66,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: licensefinder/license_finder_action@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - name: Run LicenseFinder
+        run: |
+          gem install license_finder
+          license_finder
         continue-on-error: true

--- a/crates/phenotype-casbin-wrapper/Cargo.toml
+++ b/crates/phenotype-casbin-wrapper/Cargo.toml
@@ -12,4 +12,5 @@ path = "src/lib.rs"
 casbin = "2"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
+tracing = { workspace = true }
 tokio = { version = "1", features = ["sync", "rt"] }


### PR DESCRIPTION
## **User description**
## Summary
- make Semgrep SARIF upload non-blocking when no SARIF file is produced
- replace removed `licensefinder/license_finder_action` with inline LicenseFinder gem invocation
- add missing `tracing` dependency for `phenotype-casbin-wrapper`, matching its source usage

## Validation
- `actionlint -color=false .github/workflows/sast-quick.yml`
- `git diff --check .github/workflows/sast-quick.yml crates/phenotype-casbin-wrapper/Cargo.toml`

Note: did not run cargo check in pheno because AGENTS.md says not to run cargo build/check in shared sessions.

Fixes #8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/config-only changes plus adding a missing Rust dependency; the main impact is that some security/license reporting steps will no longer fail the workflow when their artifacts/tools are unavailable.
> 
> **Overview**
> Improves the `SAST Quick Check` GitHub Actions workflow by making Semgrep SARIF upload non-blocking and replacing the removed LicenseFinder action with an inline Ruby setup + `license_finder` gem invocation (still `continue-on-error`).
> 
> Adds `tracing` as a workspace dependency to `phenotype-casbin-wrapper` to match existing `tracing::info!` usage and avoid build failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc827f9d7de8b96c25d90a1bd426cea9d71759e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Stabilize the SAST quick check workflow and fix a missing Rust dependency**

### What Changed
- The Semgrep security scan no longer fails the workflow when no SARIF report is produced
- License compliance checking now runs with a built-in Ruby setup and `license_finder` install instead of the removed GitHub Action
- The `phenotype-casbin-wrapper` crate now includes the missing tracing dependency needed by its logging calls

### Impact
`✅ Fewer CI failures from missing security scan output`
`✅ Less fragile license compliance checks`
`✅ Fewer build errors in phenotype-casbin-wrapper`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=2HLecXlGaySXFMnTwsLTb_VU6ZZZcHGRr5JfL-zoHrk&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
