### PR TITLE
fix: bump rust-version 1.75 → 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.2.0"
 edition = "2021"
 license = "MIT"
-rust-version = "1.75"
+rust-version = "1.86"
 authors = ["Phenotype Team"]
 repository = "https://github.com/KooshaPari/phenotype-shared"
 description = "Phenotype Infrastructure Kit"


### PR DESCRIPTION
## Summary
- Bumps rust-version from 1.75 to 1.86 in workspace manifest
- Aligns with current Phenotype org Rust version standard

## Test plan
- [ ] CI passes (Linux + macOS)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the workspace minimum supported Rust toolchain version, but it may break builds for consumers/CI still pinned to Rust 1.75.
> 
> **Overview**
> Updates the workspace `Cargo.toml` to require Rust `1.86` (MSRV bump from `1.75`) for all crates in the workspace, aligning builds and CI with the newer toolchain requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003f402435893c1c05e063ce11c4961d4b6f33bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->