### PR TITLE
fix(deps): patchable CVE bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,15 +1052,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1084,9 +1083,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/crates/agileplus-git/Cargo.toml
+++ b/crates/agileplus-git/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 [dependencies]
 agileplus-domain = { path = "../agileplus-domain" }
 git2 = { version = "0.20", features = ["vendored-libgit2"] }
-gix = { version = "0.71", default-features = false, features = ["worktree-stream", "revision"] }
+gix = { version = "0.83", default-features = false, features = ["worktree-stream", "revision"] }
 notify = "8"
 async-nats = "0.46"
 tokio = { version = "1", features = ["sync", "time", "macros"] }


### PR DESCRIPTION
Automated dependency updates for open high-severity Dependabot alerts.

- Bumped \\openssl\\ lockfile to \\

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only lockfile and version constraint changes for CVE remediation; no auth or business logic touched, though the large `gix` semver jump warrants normal CI/regression on git workflows.
> 
> **Overview**
> Addresses open security advisories by bumping transitive and direct dependencies, with no application logic changes in the diff.
> 
> **`agileplus-git`** raises **`gix`** from **0.71** to **0.83**, keeping the same feature set (`worktree-stream`, `revision`). That aligns the gitoxide stack with patched releases for path traversal and related **`gix-*`** issues that were blocking audit/deny gates.
> 
> **`Cargo.lock`** picks up **`openssl`** **0.10.79** and **`openssl-sys`** **0.9.116**, and drops **`once_cell`** from the **`openssl`** dependency list as part of the crate update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff0dd535e38fcf8737f961f2e0bf4d41a09ac52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->