### PR TITLE
chore(obs): shared .env.example + tracing-init

### DIFF
--- a/agileplus/.env.example
+++ b/agileplus/.env.example
@@ -15,3 +15,25 @@ SENTRY_ENVIRONMENT=development
 
 # Enable debug logging from Sentry SDK
 # RUST_LOG=sentry=debug
+
+# Global log/tracing levels
+# Controls fallback level for any AgilePlus binary (overridable via RUST_LOG)
+RUST_LOG=info
+AGILEPLUS_LOG_LEVEL=info
+
+# OpenTelemetry endpoint (shared across binaries)
+# Set this to enable OTLP tracing export.
+# Example: http://localhost:4317
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+AGILEPLUS_OTLP_ENDPOINT=http://localhost:4317
+
+# AgilePlus config overrides
+AGILEPLUS_CORE_DB_PATH=$HOME/.agileplus/agileplus.db
+AGILEPLUS_CORE_SPECS_DIR=agileplus
+AGILEPLUS_TELEMETRY_LOG_LEVEL=info
+AGILEPLUS_API_PORT=3000
+AGILEPLUS_GRPC_PORT=50051
+API_PORT=3000
+AGILEPLUS_API_HOST=127.0.0.1
+API_HOST=127.0.0.1
+AGILEPLUS_DASHBOARD_PORT=3000

--- a/agileplus/crates/agileplus-api/.env.example
+++ b/agileplus/crates/agileplus-api/.env.example
@@ -1,0 +1,22 @@
+# AgilePlus API service environment
+
+# Database URL (sqlite: scheme required by load_runtime_config)
+DATABASE_URL=sqlite:$HOME/.agileplus/agileplus.db
+
+# Host and port for HTTP API
+API_HOST=127.0.0.1
+AGILEPLUS_API_HOST=127.0.0.1
+AGILEPLUS_HTTP_PORT=3000
+API_PORT=3000
+AGILEPLUS_GRPC_PORT=50051
+
+# Core + telemetry overrides
+AGILEPLUS_CORE_DB_PATH=$HOME/.agileplus/agileplus.db
+AGILEPLUS_CORE_SPECS_DIR=agileplus
+AGILEPLUS_TELEMETRY_LOG_LEVEL=info
+
+# Tracing / logs
+RUST_LOG=info
+AGILEPLUS_LOG_LEVEL=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+AGILEPLUS_OTLP_ENDPOINT=http://localhost:4317

--- a/agileplus/crates/agileplus-api/src/main.rs
+++ b/agileplus/crates/agileplus-api/src/main.rs
@@ -11,11 +11,19 @@ use agileplus_git::GitVcsAdapter;
 use agileplus_sqlite::SqliteStorageAdapter;
 use agileplus_telemetry::{TelemetryAdapter, config::TelemetryConfig};
 use anyhow::{Context, Result, anyhow};
+use tracing::level_filters::LevelFilter;
 use tracing::warn;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let config = load_runtime_config()?;
+    let log_level = config
+        .telemetry
+        .log_level
+        .parse::<LevelFilter>()
+        .unwrap_or(LevelFilter::INFO);
+    agileplus_telemetry::tracing_init::init_tracing("agileplus-api", log_level);
+
     ensure_database_parent(&config.core.database_path)?;
     let addr = bind_address(&config)?;
 

--- a/agileplus/crates/agileplus-cli/src/main.rs
+++ b/agileplus/crates/agileplus-cli/src/main.rs
@@ -17,6 +17,7 @@ use agileplus_cli::commands::{
 use agileplus_git::GitVcsAdapter;
 use agileplus_sqlite::SqliteStorageAdapter;
 use agileplus_subcmds::{DashboardArgs, PlatformArgs, run_dashboard, run_platform};
+use tracing::level_filters::LevelFilter;
 
 mod agent_stub;
 use agent_stub::StubAgentAdapter;
@@ -79,15 +80,11 @@ async fn main() {
 
     // Configure logging based on verbosity
     let log_level = match cli.verbose {
-        0 => tracing::Level::INFO,
-        1 => tracing::Level::DEBUG,
-        _ => tracing::Level::TRACE,
+        0 => LevelFilter::INFO,
+        1 => LevelFilter::DEBUG,
+        _ => LevelFilter::TRACE,
     };
-    tracing_subscriber::fmt()
-        .with_max_level(log_level)
-        .with_target(false)
-        .compact()
-        .init();
+    agileplus_telemetry::tracing_init::init_tracing("agileplus-cli", log_level);
 
     if let Err(e) = run(cli).await {
         eprintln!("Error: {e:#}");

--- a/agileplus/crates/agileplus-dashboard/src/main.rs
+++ b/agileplus/crates/agileplus-dashboard/src/main.rs
@@ -5,10 +5,11 @@ use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
 use tracing::info;
+use tracing::level_filters::LevelFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init();
+    agileplus_telemetry::tracing_init::init_tracing("agileplus-dashboard", LevelFilter::INFO);
 
     let port = std::env::var("AGILEPLUS_DASHBOARD_PORT")
         .ok()

--- a/agileplus/crates/agileplus-telemetry/src/lib.rs
+++ b/agileplus/crates/agileplus-telemetry/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod logs;
 pub mod metrics;
 pub mod traces;
+pub mod tracing_init;
 
 use agileplus_domain::ports::observability::{LogEntry, LogLevel, ObservabilityPort, SpanContext};
 use opentelemetry::global;

--- a/agileplus/crates/agileplus-telemetry/src/tracing_init.rs
+++ b/agileplus/crates/agileplus-telemetry/src/tracing_init.rs
@@ -1,0 +1,37 @@
+//! Shared tracing bootstrap used by all AgilePlus binaries.
+
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
+
+/// Initialize the process-wide tracing subscriber.
+///
+/// - Uses `EnvFilter` so `RUST_LOG` can override behavior.
+/// - Uses the crate-level telemetry layer when OTEL endpoint is configured.
+pub fn init_tracing(service_name: &str, fallback_level: tracing::level_filters::LevelFilter) {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(format!("{}={}", service_name, fallback_level)));
+
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .ok()
+        .or_else(|_| std::env::var("AGILEPLUS_OTLP_ENDPOINT").ok());
+
+    let subscriber = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer().with_target(false).compact());
+
+    if let Some(endpoint) = otlp_endpoint {
+        // Keep OpenTelemetry endpoints compatible across both naming styles.
+        std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint);
+
+        if let Err(err) = crate::traces::init_tracer() {
+            tracing::warn!(error = %err, "failed to initialize tracer provider");
+            let _ = subscriber.try_init();
+            return;
+        }
+
+        let subscriber = subscriber.with(crate::traces::telemetry_layer());
+        let _ = subscriber.try_init();
+        return;
+    }
+
+    let _ = subscriber.try_init();
+}


### PR DESCRIPTION
## Summary
- Add root .env.example updates for shared logging/telemetry and core/runtime env variables.
- Add crates/agileplus-api/.env.example with API-specific overrides.
- Add shared tracing bootstrap in gileplus-telemetry (	racing_init::init_tracing).
- Wire shared tracer init into gileplus-cli, gileplus-api, and gileplus-dashboard mains.

## Notes
- gileplus-governance binary not present in this checkout, so wiring was applied to all discoverable AgilePlus Rust mains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and documentation only; OTLP failures fall back to stdout logging without changing business logic.
> 
> **Overview**
> Documents shared **logging, OTLP, and runtime config** env vars in the root `.env.example` and adds a dedicated **`agileplus-api/.env.example`** for API/database/bind settings.
> 
> Introduces **`tracing_init::init_tracing`** in `agileplus-telemetry`: one subscriber setup with `EnvFilter` (`RUST_LOG` or per-service fallback), compact stdout logging, and optional OTLP export when `OTEL_EXPORTER_OTLP_ENDPOINT` or `AGILEPLUS_OTLP_ENDPOINT` is set (with warn-and-continue if tracer init fails).
> 
> **CLI, API, and dashboard** mains now call this helper instead of each configuring `tracing_subscriber` locally; API uses telemetry config log level, CLI keeps `-v` verbosity mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2d56b3a9b6f2ab1060e107b97fee1574987261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->