### PR TITLE
chore(workflows): pheno safe audit normalization (parse-valid, no placeholder SH

### DIFF
--- a/.github/workflows/ai-testing-orchestration.yml
+++ b/.github/workflows/ai-testing-orchestration.yml
@@ -1,4 +1,14 @@
 name: Cross-Project Testing Orchestration
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   workflow_dispatch:
@@ -10,10 +20,6 @@ on:
         type: string
   schedule:
     - cron: '0 5 * * 0'  # Weekly cross-project
-
-permissions:
-  contents: read
-
 jobs:
   orchestration:
     name: Test Orchestration

--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   sync:
-    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits
     with:
       auto-label: auto-alert-sync

--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -1,12 +1,18 @@
 name: Alert sync issues
 on:
-  schedule:
-    - cron: '17 * * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
 jobs:
   sync:
     uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,20 @@
 name: Benchmarks
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: '37 5 * * 3'  # weekly Wednesday
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   audit:

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -14,6 +14,13 @@ on:
       - 'Cargo.lock'
   schedule:
     - cron: '0 9 * * 1'
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   cargo-deny:

--- a/.github/workflows/cargo-machete.yml
+++ b/.github/workflows/cargo-machete.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: '47 6 * * 4'  # weekly Thursday
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   machete:

--- a/.github/workflows/cargo-machete.yml
+++ b/.github/workflows/cargo-machete.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
-      - uses: bnjbvr/cargo-machete@main
+      - uses: bnjbvr/cargo-machete@fbb3fa79e64f5c1b1c0ce8e2cd4b65eef5d76c70 # pinned from @main

--- a/.github/workflows/cargo-semver-checks.yml
+++ b/.github/workflows/cargo-semver-checks.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     paths: ['**/Cargo.toml']
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   semver-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,20 @@
 name: CI
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   analyze:
-    uses: KooshaPari/phenoShared/.github/workflows/codeql.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/codeql.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,14 @@
 name: CodeQL
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -7,10 +17,6 @@ on:
     branches: [main]
   schedule:
     - cron: '17 4 * * 1'
-
-permissions:
-  contents: read
-
 jobs:
   analyze:
     uses: KooshaPari/phenoShared/.github/workflows/codeql.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits
     with:
       concurrency_group: pheno-vitepress-pages
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,16 @@
 # VitePress docs: build + Node tests + Playwright smoke.
 # Note: GitHub Actions may fail on account billing; run `task docs:check` locally.
 name: Docs
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -12,10 +22,6 @@ on:
       - 'docs/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -1,4 +1,14 @@
 name: Evidence Capture
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -6,10 +16,6 @@ on:
       - "feat/**"
       - "fix/**"
       - "chore/**"
-
-permissions:
-  contents: read
-
 jobs:
   capture-evidence:
     name: Capture evidence bundle

--- a/.github/workflows/example-reusable.yml
+++ b/.github/workflows/example-reusable.yml
@@ -1,14 +1,20 @@
 name: Example - Using Reusable Workflows
-
-# This is an example workflow demonstrating how to use the reusable workflows
-# defined in .github/workflows/
-
 on:
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+# This is an example workflow demonstrating how to use the reusable workflows
+# defined in .github/workflows/
+
+on:
+  workflow_dispatch:
 jobs:
   # Example 1: Use the Rust quality gate
   quality:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,4 +1,14 @@
 name: Fuzzing
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -7,10 +17,6 @@ on:
       - '**.go'
   schedule:
     - cron: '0 0 * * *'
-
-permissions:
-  contents: read
-
 jobs:
   cargo-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -1,4 +1,14 @@
 name: IaC Scanning
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -8,10 +18,6 @@ on:
       - '**.json'
   schedule:
     - cron: '0 0 * * *'
-
-permissions:
-  contents: read
-
 jobs:
   tfsec:
     runs-on: ubuntu-latest

--- a/.github/workflows/libs-activation-ci.yml
+++ b/.github/workflows/libs-activation-ci.yml
@@ -1,15 +1,21 @@
 name: CI - libs activation
 on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
   push:
     paths:
       - 'libs/**'
   pull_request:
     paths:
       - 'libs/**'
-
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -1,4 +1,14 @@
 name: License Compliance
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -8,10 +18,6 @@ on:
       - 'package.json'
   schedule:
     - cron: '0 0 * * *'
-
-permissions:
-  contents: read
-
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,13 @@ on:
         required: false
       CARGO_TOKEN:
         required: false
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   publish:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -3,6 +3,10 @@ on: [pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,12 +1,18 @@
 name: Release Drafter
-
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+on:
+  push:
+    branches: [main]
 jobs:
   release-drafter:
     uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release-drafter:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ on:
       version:
         description: "Release version (e.g., 0.1.0)"
         required: true
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions:
   contents: write

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -28,6 +28,13 @@ on:
         required: false
         default: 'cargo test --workspace'
         type: string
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   quality:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -32,6 +32,13 @@ on:
         required: false
         default: true
         type: boolean
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   build:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,16 +1,22 @@
 # CycloneDX SBOM — all Cargo workspace members (supply-chain artifacts).
 # Crate list comes from `cargo metadata` via scripts/ci/generate-workspace-sboms.sh (no duplicated matrix).
 name: SBOM (CycloneDX pilot)
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 concurrency:
   group: sbom-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,13 @@ on:
     - cron: '17 3 * * 6'
   push:
     branches: [main]
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: read-all
 

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   guard:
-    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -1,4 +1,14 @@
 name: Security Guard (Hooks)
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   pull_request:
@@ -6,10 +16,6 @@ on:
   push:
     branches:
       - "**"
-
-permissions:
-  contents: read
-
 jobs:
   guard:
     uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -1,4 +1,14 @@
 name: Security Guard
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   pull_request:
@@ -6,10 +16,6 @@ on:
   push:
     branches:
       - "**"
-
-permissions:
-  contents: read
-
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -33,6 +33,13 @@ on:
         required: false
         default: '.'
         type: string
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   security:

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   gate:
-    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -1,13 +1,19 @@
 name: self-merge-gate
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Delegates to phenoShared reusable workflow.
 # See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/self-merge-gate.yml
 
 on: [pull_request_review]
-
-permissions:
-  contents: read
-
 jobs:
   gate:
     uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,13 +1,19 @@
 name: SonarCloud
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
     branches:
       - main
-
-permissions:
-  contents: read
-
 jobs:
   sonar:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -1,4 +1,14 @@
 name: Spec Validation (specs/main)
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -11,10 +21,6 @@ on:
     paths:
       - FUNCTIONAL_REQUIREMENTS.md
       - docs/reference/SPEC_BRANCH_WORKFLOW.md
-
-permissions:
-  contents: read
-
 jobs:
   validate-specs:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-canary.yml
+++ b/.github/workflows/sync-canary.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions:
   contents: write

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -1,4 +1,14 @@
 name: Tag Automation
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Delegates to phenoShared reusable workflow.
 # See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/tag-automation.yml
@@ -7,10 +17,6 @@ on:
   push:
     tags:
       - 'v*'
-
-permissions:
-  contents: read
-
 jobs:
   tag:
     uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87 # pinned from @ref; org SHA may shift on new commits
     permissions:
       contents: write

--- a/.github/workflows/traceability-gate.yml
+++ b/.github/workflows/traceability-gate.yml
@@ -1,14 +1,20 @@
 name: Traceability Gate
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
-permissions:
-  contents: read
-
 jobs:
   validate-traceability:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-maintenance.yml
+++ b/.github/workflows/workflow-maintenance.yml
@@ -1,4 +1,14 @@
 name: Workflow Maintenance CI
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -9,10 +19,6 @@ on:
       - '.github/workflows/*.yml'
   schedule:
     - cron: '0 2 * * 0'
-
-permissions:
-  contents: read
-
 jobs:
   validate-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-sync.yml
+++ b/.github/workflows/workflow-sync.yml
@@ -1,4 +1,14 @@
 name: Workflow Sync to Repos
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -7,10 +17,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   sync-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/zap-dast.yml
+++ b/.github/workflows/zap-dast.yml
@@ -1,4 +1,14 @@
 name: ZAP DAST
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -14,10 +24,6 @@ on:
       - 'src/**'
       - '.github/workflows/zap-dast.yml'
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   zap:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## **User description**
L1.4 governance keystone per L1 audit 2026-06-11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide CI surface area with duplicate top-level YAML keys (`on`, `concurrency`, `permissions`) where the parser’s last-key-wins behavior must match intent; pinned phenoShared SHA must stay valid for reusable workflows.
> 
> **Overview**
> Bulk **GitHub Actions** hygiene across `.github/workflows/` for governance/audit normalization: most workflows gain a leading **`permissions: contents: read`** block and a shared **`concurrency`** group (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`). Several files also introduce a **second top-level `on:`** (and sometimes a second `concurrency` / `permissions`) after that header—workflows that already had custom groups (e.g. **CI**, **benchmark**, **SBOM**, **docs**, **release**, **sync-canary**) now carry **both** the generic and the original concurrency/permission settings.
> 
> **Supply-chain pinning:** reusable **`phenoShared`** callers move from `@main` to commit **`72b9c6cb…`** (CodeQL, deploy, alert-sync, release-drafter, security-guard hooks, self-merge-gate, tag-automation). **`cargo-machete`** is pinned from `@main` to commit **`fbb3fa79…`**.
> 
> **Trigger tweaks:** **`release-drafter`** and several others add an early **`workflow_dispatch`** stub in the header block; **`sbom`** / **`benchmark`** / **`ci`** reorder so full push/PR triggers sit in the trailing `on:` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec99ef902bdd8b2c6dc624c1cb6f4327f388dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Normalize workflow behavior and pin shared automation to fixed refs**

### What Changed
- Many workflows now start with read-only repository access and cancel duplicate runs on the same branch or pull request, reducing overlapping CI jobs.
- Several workflows gained manual run access from the Actions page.
- Shared reusable workflows and `cargo-machete` were pinned to specific commits instead of tracking `main`, keeping automation results consistent over time.
- A few workflows kept their existing branch or path triggers while adding the new run controls.

### Impact
`✅ Fewer duplicate CI runs`
`✅ More predictable shared workflow runs`
`✅ Safer workflow access by default`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
