### PR TITLE
L1.4 governance keystone per L1 audit 2026-06-12

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,53 @@
+name: Governance Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  governance:
+    name: L1 Governance Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Verify required governance artifacts exist
+        run: |
+          set -euo pipefail
+          missing=()
+          for f in SECURITY.md CODEOWNERS cliff.toml .github/dependabot.yml; do
+            if [ ! -f "$f" ]; then
+              echo "::error file=$f::Required governance file missing"
+              missing+=("$f")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "Missing governance files: ${missing[*]}"
+            exit 1
+          fi
+          echo "All required governance files present."
+
+      - name: Validate CODEOWNERS syntax
+        run: |
+          test -s CODEOWNERS || (echo "CODEOWNERS is empty" && exit 1)
+          grep -E '\S' CODEOWNERS | grep -v '^#' | head -1
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Governance L1 check: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## **User description**
L1.4 governance keystone per L1 audit 2026-06-12

Adds fleet-standard governance workflow file:
- .github/workflows/governance.yml

Source: side-215/216/217 local commit `9cbe53b chore(governance): add missing governance files`, rebased onto current origin/main.

Note: pre-existing WIP (perf-budget + working-tree edits) was stashed to `side-219-stash-wip`; not part of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CI checks only; no application or deployment behavior changes.
> 
> **Overview**
> Introduces a new **L1 Governance Gate** GitHub Actions workflow (`.github/workflows/governance.yml`) that enforces presence of fleet-standard governance artifacts on pushes and PRs to `main`, plus a weekly Monday 06:00 UTC schedule and manual `workflow_dispatch`.
> 
> The job checks out with read-only permissions (`persist-credentials: false`), fails if any of `SECURITY.md`, `CODEOWNERS`, `cliff.toml`, or `.github/dependabot.yml` is missing, and performs a minimal **CODEOWNERS** sanity check (non-empty file with at least one non-comment line). A step summary records pass/fail status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71a4fd4a280267735a3af28b7c68dbec636e611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a governance check workflow for main branch changes**

### What Changed
- Adds a new governance check that runs on pushes and pull requests to `main`, on a weekly schedule, and when triggered manually
- Fails if required governance files are missing: `SECURITY.md`, `CODEOWNERS`, `cliff.toml`, or `.github/dependabot.yml`
- Checks that `CODEOWNERS` is not empty and contains at least one non-comment entry
- Publishes a short run summary so failures are easier to spot in CI

### Impact
`✅ Fewer missing governance files`
`✅ Earlier detection of broken CODEOWNERS setup`
`✅ Clearer CI checks for main-branch changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
