### PR TITLE
layer: chore/gitleaks-to-trufflehog — chore(secrets-scan): migrate gitleaks → trufflehog

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,34 +1,25 @@
-#!/bin/bash
-# Pre-commit hook to scan for secrets before commit
-# Install: cp .githooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+#!/usr/bin/env bash
+# pre-commit: trufflehog secrets scan (migrated from gitleaks 2026-04-24)
+# Justification: shell glue ≤40 lines; trufflehog is a CLI tool, Rust wrapper not warranted.
+set -euo pipefail
 
-set -e
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_DIR="$(git rev-parse --git-common-dir)"
 
-echo "🔍 Running gitleaks scan..."
+echo "🔍 Running trufflehog scan..."
 
-if ! command -v gitleaks &>/dev/null; then
-    echo "⚠️  gitleaks not installed. Install: brew install gitleaks"
+if ! command -v trufflehog &>/dev/null; then
+    echo "⚠️  trufflehog not installed. Install: brew install trufflehog"
     exit 0
 fi
 
-# Run gitleaks and capture output
-RESULT=$(gitleaks detect --redact --no-color -s . 2>&1)
-SCAN_RESULT=$?
+cd "$REPO_ROOT"
 
-# gitleaks returns 1 when leaks found, 0 when clean
-if [ $SCAN_RESULT -eq 1 ]; then
-    echo "❌ SECRET DETECTED! Commit blocked."
-    echo "$RESULT"
-    echo ""
-    echo "To bypass for legitimate false positive, use:"
-    echo "  git commit --no-verify -m 'message'"
+# Scan verified secrets only; exit non-zero on any finding.
+if ! trufflehog git "file://$REPO_ROOT" --since-commit HEAD --only-verified --fail --no-update 2>&1; then
+    echo "❌ trufflehog detected verified secrets."
     exit 1
 fi
 
-# Any other non-zero return is an error (skip)
-if [ $SCAN_RESULT -ne 0 ]; then
-    echo "⚠️  gitleaks scan error (code $SCAN_RESULT), skipping"
-    exit 0
-fi
-
-echo "✅ No secrets detected"
+echo "✅ trufflehog scan clean."
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,34 +1,25 @@
-#!/bin/bash
-# Pre-push hook to scan for secrets before push
-# Install: cp .githooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+#!/usr/bin/env bash
+# pre-push: trufflehog secrets scan (migrated from gitleaks 2026-04-24)
+# Justification: shell glue ≤40 lines; trufflehog is a CLI tool, Rust wrapper not warranted.
+set -euo pipefail
 
-set -e
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_DIR="$(git rev-parse --git-common-dir)"
 
-echo "🔍 Running gitleaks pre-push scan..."
+echo "🔍 Running trufflehog scan..."
 
-if ! command -v gitleaks &>/dev/null; then
-    echo "⚠️  gitleaks not installed. Install: brew install gitleaks"
+if ! command -v trufflehog &>/dev/null; then
+    echo "⚠️  trufflehog not installed. Install: brew install trufflehog"
     exit 0
 fi
 
-# Run gitleaks and capture output
-RESULT=$(gitleaks detect --redact --no-color -s . 2>&1)
-SCAN_RESULT=$?
+cd "$REPO_ROOT"
 
-# gitleaks returns 1 when leaks found, 0 when clean
-if [ $SCAN_RESULT -eq 1 ]; then
-    echo "❌ SECRET DETECTED! Push blocked."
-    echo "$RESULT"
-    echo ""
-    echo "To bypass for legitimate false positive, use:"
-    echo "  git push --no-verify"
+# Scan verified secrets only; exit non-zero on any finding.
+if ! trufflehog git "file://$REPO_ROOT" --since-commit HEAD --only-verified --fail --no-update 2>&1; then
+    echo "❌ trufflehog detected verified secrets."
     exit 1
 fi
 
-# Any other non-zero return is an error (skip)
-if [ $SCAN_RESULT -ne 0 ]; then
-    echo "⚠️  gitleaks scan error (code $SCAN_RESULT), skipping"
-    exit 0
-fi
-
-echo "✅ No secrets detected"
+echo "✅ trufflehog scan clean."
+exit 0

--- a/.github/actions/security-checks/action.yml
+++ b/.github/actions/security-checks/action.yml
@@ -1,5 +1,5 @@
 name: 'Security Checks'
-description: 'Run security scanning tools: cargo-audit, cargo-deny, gitleaks, and Python bandit'
+description: 'Run security scanning tools: cargo-audit, cargo-deny, trufflehog, and Python bandit'
 
 inputs:
   cargo-audit:
@@ -10,8 +10,8 @@ inputs:
     description: 'Run cargo-deny for license/advisory/duplicate checking'
     required: false
     default: 'true'
-  gitleaks:
-    description: 'Run gitleaks for secret detection in git history'
+  trufflehog:
+    description: 'Run trufflehog for secret detection in git history'
     required: false
     default: 'true'
   python-bandit:
@@ -31,7 +31,7 @@ inputs:
     required: false
     default: '.'
   checkout-depth:
-    description: 'Fetch depth (0 required for gitleaks full history)'
+    description: 'Fetch depth (0 required for trufflehog full history)'
     required: false
     default: '1'
 
@@ -60,12 +60,13 @@ runs:
           cargo deny check
         fi
 
-    - name: Gitleaks Secret Detection
-      if: inputs.gitleaks == 'true'
-      uses: gitleaks/gitleaks-action@v2
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
+    - name: Secrets scan (trufflehog)
+      if: inputs.trufflehog == 'true'
+      uses: trufflesecurity/trufflehog@main
+      with:
+        path: ./
+        base: ${{ github.event.repository.default_branch }}
+        extra_args: --only-verified
     - name: Setup Python for bandit
       if: inputs.python-bandit == 'true'
       uses: actions/setup-python@v5

--- a/.github/workflows/example-reusable.yml
+++ b/.github/workflows/example-reusable.yml
@@ -26,7 +26,7 @@ jobs:
       workspace: .
       cargo-audit: true
       cargo-deny: true
-      gitleaks: true
+      trufflehog: true
       python-bandit: false
 
   # Example 3: Build release binaries (only on tags)

--- a/.github/workflows/reusable/rust-quality.yml
+++ b/.github/workflows/reusable/rust-quality.yml
@@ -88,6 +88,6 @@ jobs:
         with:
           cargo-audit: 'true'
           cargo-deny: 'true'
-          gitleaks: 'false'
+          trufflehog: 'false'
           python-bandit: 'false'
           working-directory: ${{ inputs.workspace }}

--- a/.github/workflows/reusable/security-scan.yml
+++ b/.github/workflows/reusable/security-scan.yml
@@ -18,8 +18,8 @@ on:
         required: false
         default: true
         type: boolean
-      gitleaks:
-        description: 'Run gitleaks'
+      trufflehog:
+        description: 'Run trufflehog'
         required: false
         default: true
         type: boolean
@@ -53,7 +53,7 @@ jobs:
         with:
           cargo-audit: ${{ inputs.cargo-audit }}
           cargo-deny: ${{ inputs.cargo-deny }}
-          gitleaks: ${{ inputs.gitleaks }}
+          trufflehog: ${{ inputs.trufflehog }}
           python-bandit: ${{ inputs.python-bandit }}
           bandit-path: ${{ inputs.bandit-path }}
           working-directory: ${{ inputs.workspace }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,18 +45,20 @@ jobs:
         run: cargo deny check
 >>>>>>> origin/main
 
-  # ─── Gitleaks Secret Detection ────────────────────────────────────────
-  gitleaks:
-    name: Gitleaks
+  # ─── Trufflehog Secret Detection ────────────────────────────────────────
+  trufflehog:
+    name: Secrets scan (trufflehog)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Secrets scan (trufflehog)
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          extra_args: --only-verified
   # ─── CodeQL SAST ──────────────────────────────────────────────────────
   codeql:
     name: CodeQL


### PR DESCRIPTION
## **User description**
Layered PR: `chore/gitleaks-to-trufflehog` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how commits/pushes and CI gate on secrets (verified-only trufflehog vs prior gitleaks behavior), and the PR diff leaves merge conflicts in security.yml that would break CI if merged as-is.
> 
> **Overview**
> Replaces **gitleaks** with **trufflehog** for secret scanning across local git hooks and GitHub Actions.
> 
> **Local hooks** (`.githooks/pre-commit`, `.githooks/pre-push`) now run `trufflehog git` with `--only-verified` and `--fail`, block on verified findings, and skip when the CLI is missing. The old gitleaks capture/bypass messaging and “scan error → skip hook” behavior are removed in favor of stricter `set -euo pipefail` glue.
> 
> **CI** renames the `gitleaks` toggle to `trufflehog` in the composite `security-checks` action and wired workflows (`security-scan.yml`, `example-reusable.yml`, `rust-quality.yml` still disables it). Scanning uses `trufflesecurity/trufflehog@main` with `extra_args: --only-verified` and default-branch `base` instead of `gitleaks/gitleaks-action@v2`. The top-level `security.yml` job is renamed accordingly and uses full history checkout.
> 
> **Note:** The diff for `.github/workflows/security.yml` still contains **unresolved merge conflict markers** (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main`) around `cargo-deny` config and an `osv-scanner` job block—these must be resolved before merge or the workflow will fail to parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9458e99564200c687e4ba98d6ef02742b1fa7c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Switch secret scanning from gitleaks to trufflehog in hooks and CI

### What Changed
- Local commit and push hooks now use trufflehog to block verified secret leaks before code leaves the machine
- Security checks in GitHub Actions now run trufflehog instead of gitleaks, and the reusable workflow input was renamed to match
- Example and Rust quality workflow calls were updated so secret scanning stays enabled or disabled as intended

### Impact
`✅ Fewer secret leaks reaching commits`
`✅ Earlier push-time secret warnings`
`✅ Consistent secret scanning across local hooks and CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
