### PR TITLE
layer: chore/pheno-cheap-win-20260608 — chore(pheno-string): rename NormalizationForm variants to fi

### DIFF
--- a/crates/phenotype-string/src/normalization.rs
+++ b/crates/phenotype-string/src/normalization.rs
@@ -6,13 +6,13 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NormalizationForm {
     /// NFC - Canonical Decomposition followed by Canonical Composition
-    NFC,
+    Nfc,
     /// NFD - Canonical Decomposition
-    NFD,
+    Nfd,
     /// NFKC - Compatibility Decomposition followed by Canonical Composition
-    NFKC,
+    Nfkc,
     /// NFKD - Compatibility Decomposition
-    NFKD,
+    Nfkd,
 }
 
 /// Normalize a string to the specified Unicode normalization form
@@ -23,7 +23,7 @@ pub enum NormalizationForm {
 /// use phenotype_string::normalization::{normalize, NormalizationForm};
 ///
 /// let text = "café";
-/// let normalized = normalize(text, NormalizationForm::NFC).unwrap();
+/// let normalized = normalize(text, NormalizationForm::Nfc).unwrap();
 /// assert_eq!(normalized, text);
 /// ```
 pub fn normalize(text: &str, _form: NormalizationForm) -> crate::Result<String> {
@@ -40,7 +40,7 @@ pub fn normalize(text: &str, _form: NormalizationForm) -> crate::Result<String> 
 /// use phenotype_string::normalization::{is_normalized, NormalizationForm};
 ///
 /// let text = "Hello";
-/// assert!(is_normalized(text, NormalizationForm::NFC).unwrap());
+/// assert!(is_normalized(text, NormalizationForm::Nfc).unwrap());
 /// ```
 pub fn is_normalized(_text: &str, _form: NormalizationForm) -> crate::Result<bool> {
     // Stub implementation - always returns true
@@ -55,13 +55,13 @@ mod tests {
     #[test]
     fn test_normalize() {
         let text = "Hello, World!";
-        let normalized = normalize(text, NormalizationForm::NFC).unwrap();
+        let normalized = normalize(text, NormalizationForm::Nfc).unwrap();
         assert_eq!(normalized, text);
     }
 
     #[test]
     fn test_is_normalized() {
         let text = "Hello";
-        assert!(is_normalized(text, NormalizationForm::NFC).unwrap());
+        assert!(is_normalized(text, NormalizationForm::Nfc).unwrap());
     }
 }


### PR DESCRIPTION
## **User description**
Layered PR: `chore/pheno-cheap-win-20260608` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Naming-only change in a single crate with no logic changes; any external callers using the old variant names must update.
> 
> **Overview**
> Renames the public `NormalizationForm` enum variants from all-caps Unicode labels (`NFC`, `NFD`, `NFKC`, `NFKD`) to **UpperCamelCase** (`Nfc`, `Nfd`, `Nfkc`, `Nfkd`) in `normalization.rs`. Doc examples, tests, and doctest snippets are updated to use the new variant names; normalization behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9cc2328ef0c20452e0315d0f94fb2f6a0011ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Rename Unicode normalization variants to Rust-style names

### What Changed
- The public normalization variants now use `Nfc`, `Nfd`, `Nfkc`, and `Nfkd` instead of all-caps names
- Examples and tests were updated to show the new variant names
- Normalization results and behavior stay the same

### Impact
`✅ Clearer API names`
`✅ Fewer style warnings`
`✅ Updated examples and tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
