### PR TITLE
layer: chore/pin-actions — recovery/2026-06-06: pheno/pin-actions-pheno (38 WIP files, 

### DIFF
--- a/.github/workflows/ai-testing-orchestration.yml
+++ b/.github/workflows/ai-testing-orchestration.yml
@@ -1,5 +1,9 @@
 name: Cross-Project Testing Orchestration
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -1,4 +1,8 @@
 name: Alert sync issues
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: '17 * * * *'
@@ -9,6 +13,6 @@ permissions:
 
 jobs:
   sync:
-    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87
     with:
       auto-label: auto-alert-sync

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,9 @@
 name: Audit Workspace
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
         with:
           workspaces: rust
       - uses: arduino/setup-protoc@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Check for benches directory
         id: check-benches
         run: |
@@ -52,6 +52,6 @@ jobs:
         with:
           tool: 'cargo'
           output-file-path: target/criterion/output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           auto-push: true
         continue-on-error: true

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,4 +1,7 @@
 name: cargo-audit
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,4 +24,4 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
       - uses: rustsec/audit-check@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
 
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,5 +1,11 @@
 name: cargo-deny
 
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/cargo-machete.yml
+++ b/.github/workflows/cargo-machete.yml
@@ -1,4 +1,7 @@
 name: cargo-machete
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,4 +22,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
-      - uses: bnjbvr/cargo-machete@main
+      - uses: bnjbvr/cargo-machete@fbb3fa76a4af23b0146dc1b1c248965a300282e8

--- a/.github/workflows/cargo-semver-checks.yml
+++ b/.github/workflows/cargo-semver-checks.yml
@@ -1,4 +1,7 @@
 name: cargo-semver-checks
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,9 @@
 name: Generate Changelog
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
         with:
           workspaces: rust
       - uses: arduino/setup-protoc@v3
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
         with:
           workspaces: rust
       - uses: arduino/setup-protoc@v3
@@ -82,8 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
         with:
           workspaces: rust
       - uses: arduino/setup-protoc@v3
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
         with:
           workspaces: rust
       - uses: arduino/setup-protoc@v3
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
         with:
           workspaces: rust
       - uses: arduino/setup-protoc@v3
@@ -170,7 +170,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@1.100.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
@@ -218,7 +218,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Format check
         run: cd rust && cargo fmt --check
       - name: Clippy (warnings = errors)
@@ -73,7 +73,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Build
         run: cd rust && cargo build --all
 
@@ -89,7 +89,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Check MSRV compatibility
         run: cd rust && cargo check
 
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: rustsec/audit-check@v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check licenses, advisories, duplicates
@@ -123,7 +123,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Install extras
         run: cargo install cargo-machete cargo-semver-checks
       - name: Detect unused deps
@@ -146,7 +146,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Generate coverage
@@ -174,7 +174,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Format check
         run: cargo fmt --all -- --check
       - name: Clippy (warnings = errors)
@@ -194,7 +194,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Build
         run: cargo build --workspace
 
@@ -208,7 +208,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Check MSRV compatibility
         run: cargo check --workspace
 
@@ -222,7 +222,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Build docs
         run: cargo doc --no-deps --workspace
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   analyze:
-    uses: KooshaPari/phenoShared/.github/workflows/codeql.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/codeql.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87
     with:
       concurrency_group: pheno-vitepress-pages
     permissions:

--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
 

--- a/.github/workflows/example-reusable.yml
+++ b/.github/workflows/example-reusable.yml
@@ -1,5 +1,9 @@
 name: Example - Using Reusable Workflows
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # This is an example workflow demonstrating how to use the reusable workflows
 # defined in .github/workflows/
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz || true
       - name: Run fuzzing

--- a/.github/workflows/gate-check.yml
+++ b/.github/workflows/gate-check.yml
@@ -1,5 +1,9 @@
 name: Gate Check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/libs-activation-ci.yml
+++ b/.github/workflows/libs-activation-ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       - name: Build phenotype-auth
         working-directory: libs/phenotype-auth
         run: |

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,5 +1,9 @@
 name: Promote Package
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,11 @@
 name: Publish Package
 
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-drafter:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross
@@ -159,7 +159,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "./release-assets/*"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           draft: false
           prerelease: false
           generateReleaseNotes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
             use_cross: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
       - uses: arduino/setup-protoc@v3
         with:
           version: "28.x"
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       - name: Install cargo-cyclonedx
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -1,5 +1,11 @@
 name: Rust Quality Gate
 
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,5 +1,11 @@
 name: Rust Release Build
 
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sast-full.yml
+++ b/.github/workflows/sast-full.yml
@@ -1,5 +1,9 @@
 name: SAST Full Analysis
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: "0 2 * * *"

--- a/.github/workflows/sast-full.yml
+++ b/.github/workflows/sast-full.yml
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: trivy-results.sarif
@@ -65,7 +65,7 @@ jobs:
           generateSarif: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         if: always() && hashFiles('semgrep.sarif') != ''
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/sast-quick.yml
+++ b/.github/workflows/sast-quick.yml
@@ -32,7 +32,7 @@ jobs:
           generateSarif: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   license-check:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
 
       - name: Install cargo-cyclonedx
         uses: taiki-e/install-action@v2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   guard:
-    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,5 +1,11 @@
 name: Security Scan
 
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Upload OSV SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         with:
           sarif_file: ${{ inputs.workspace }}/osv-results.sarif
           category: osv-cargo-lock

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: rustsec/audit-check@v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
   cargo-deny:
     name: Cargo Deny
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   codeql:
     name: CodeQL

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check advisories, licenses, duplicates
@@ -92,7 +92,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       - name: Generate Cargo.lock for scanning
         run: cargo generate-lockfile
       - name: Install OSV-Scanner
@@ -109,7 +109,7 @@ jobs:
       - name: Upload OSV SARIF to GitHub Code Scanning
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         with:
           sarif_file: osv-results.sarif
           category: osv-cargo-lock

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   gate:
-    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         with:
           sarif_file: snyk.sarif
           category: snyk-security-scan

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@72b9c6cbdb24c49189b0e7c7395d874830d1ed87
     permissions:
       contents: write

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -29,7 +29,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9fc351a8ac7432cff4cf6b2e45db91873bec9bf9
         with:
           sarif_file: 'trivy-results.sarif'
         continue-on-error: true

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
       - name: TruffleHog OSS

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,4 +1,7 @@
 name: TruffleHog Secrets Scan
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@5f47aad1c2df34f7c6230784ce9a5a659922f479
         with:
           path: ./
           base_depth: 1

--- a/agileplus-agents/.github/workflows/release.yml
+++ b/agileplus-agents/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: ${{ needs.release.outputs.version }}
           channel: beta

--- a/agileplus-mcp/.github/workflows/release.yml
+++ b/agileplus-mcp/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/forgecode-fork/.github/workflows/release.yml
+++ b/forgecode-fork/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/pheno-cli/.github/workflows/ci.yml
+++ b/pheno-cli/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
 
   phenotype-validate:
     runs-on: ubuntu-latest
-    uses: KooshaPari/phenotypeActions/.github/workflows/validate-governance.yml@main
+    uses: KooshaPari/phenotypeActions/.github/workflows/validate-governance.yml@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable

--- a/pheno-cli/.github/workflows/release.yml
+++ b/pheno-cli/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/phenotype-infrakit/.github/workflows/release.yml
+++ b/phenotype-infrakit/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/phenotype-router-monitor/.github/workflows/release.yml
+++ b/phenotype-router-monitor/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/python/.github/workflows/release.yml
+++ b/python/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/rust/.github/workflows/release.yml
+++ b/rust/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/template-python/.github/workflows/release.yml
+++ b/template-python/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta

--- a/template-rust/.github/workflows/release.yml
+++ b/template-rust/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Promote to staging
-        uses: KooshaPari/phenotypeActions/promote@main
+        uses: KooshaPari/phenotypeActions/promote@0000000000000000000000000000000000000000 # placeholder SHA; source 404s; replace when reachable
         with:
           version: $123needs.release.outputs.version125
           channel: beta


### PR DESCRIPTION
## **User description**
Layered PR: `chore/pin-actions` → integration/consolidate (2 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide CI workflow changes can alter run behavior or permissions; placeholder phenotypeActions SHAs will fail release promote and governance validation jobs until updated.
> 
> **Overview**
> This PR **hardens CI across the monorepo** by pinning third-party and reusable workflow refs to commit SHAs, adding **workflow-level concurrency** (`cancel-in-progress: true`) on many jobs, and declaring **`permissions: contents: read`** where it was missing.
> 
> **Action pinning** replaces floating tags like `@v2`, `@stable`, and `@main` with fixed SHAs for `Swatinem/rust-cache`, `dtolnay/rust-toolchain` (stable path), `bnjbvr/cargo-machete`, `github/codeql-action/upload-sarif`, `trufflesecurity/trufflehog`, and pinned `actions/checkout` in `trufflehog.yml`. **Reusable workflows** from `KooshaPari/phenoShared` move from `@main` to SHA `72b9c6c…` (CodeQL, deploy, release-drafter, merge gate, tag automation, alert sync, security guard).
> 
> **Token usage** shifts routine API access from `${{ secrets.GITHUB_TOKEN }}` to `${{ github.token }}` in audit, benchmark, CI, release, and security workflows.
> 
> **Release / governance caveat:** Multiple package `release.yml` files and `pheno-cli` CI now reference `KooshaPari/phenotypeActions` at an **all-zero placeholder SHA** (with comments that the source 404s). **Promote** steps and **validate-governance** will not run successfully until those refs are replaced with a real commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094e170ba92c4310c7dcdf5ecfb4dec3b968861f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Pin CI and release workflows to fixed references, and tighten workflow access**

### What Changed
- Many workflows now use fixed commit references instead of floating tags or branch names, reducing unexpected changes from third-party actions and shared workflows.
- Several CI, security, and reusable workflows now run with read-only access and cancel older runs on the same branch, cutting down overlapping jobs.
- A number of workflows now use the built-in GitHub token directly for scans, uploads, and releases.
- Release and promotion workflows for several packages now point to a placeholder shared-workflow reference, so promotion and governance checks will not succeed until that reference is replaced.

### Impact
`✅ Fewer surprise CI changes`
`✅ Less duplicate workflow running`
`✅ Clearer release and security job behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
