### PR TITLE
layer: chore/pin-github-actions-shas — chore: pin all GitHub Actions to commit SHAs

### DIFF
--- a/crates/agileplus-sqlite/src/event_store.rs
+++ b/crates/agileplus-sqlite/src/event_store.rs
@@ -1,7 +1,7 @@
 use agileplus_domain::domain::event::Event;
 use agileplus_events::{EventError, EventStore};
 
-use crate::adapter::SqliteStorageAdapter;
+use crate::SqliteStorageAdapter;
 use crate::repository::events;
 
 #[async_trait::async_trait]

--- a/forgecode-fork/.github/workflows/ci.yml
+++ b/forgecode-fork/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run checks
         run: echo "Add project-specific checks here"

--- a/repos/.github/workflows/ci.yml
+++ b/repos/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run checks
         run: echo "Add project-specific checks here"


### PR DESCRIPTION
## **User description**
Layered PR: `chore/pin-github-actions-shas` → integration/consolidate (2 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow pinning and a one-line Rust import path change; no runtime or security logic changes.
> 
> **Overview**
> Pins **`actions/checkout`** from the floating **`@v4`** tag to commit **`34e114876b0b11c390a56381ad16ebd13914f8d5`** in the root CI workflows under **`forgecode-fork/.github/workflows/ci.yml`** and **`repos/.github/workflows/ci.yml`**, so CI runs a fixed revision instead of whatever the tag resolves to.
> 
> Also updates **`event_store.rs`** to import **`SqliteStorageAdapter`** from **`crate::`** instead of **`crate::adapter::`**, matching where that type is exposed in the crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611d33c56b57735daa080d8be634dca4e424933e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep CI runs on a fixed checkout version and restore the SQLite event store import**

### What Changed
- CI workflows now use a fixed `actions/checkout` revision instead of the moving `v4` tag, so the same workflow version runs each time
- The SQLite event store now imports `SqliteStorageAdapter` from its public crate path, which keeps the code building with the expected module layout

### Impact
`✅ More consistent CI runs`
`✅ Fewer workflow surprises from upstream action changes`
`✅ Fewer build errors in the SQLite event store`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
