### PR TITLE
layer: codex/fix-pheno-shared-callers — ci(workflows): pin phenoShared callers and fix CodeQL target

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,8 +38,8 @@ language_rules:
       - "async_await_patterns"
     patterns_to_watch:
       - "^unsafe "
-      - "\.unwrap\(\)"
-      - "\.expect\("
+      - '\.unwrap\(\)'
+      - '\.expect\('
       - "std::panic"
     complexity_threshold: 15  # Cognitive complexity
 

--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   sync:
-    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
     with:
       auto-label: auto-alert-sync

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   analyze:
-    uses: KooshaPari/phenoShared/.github/workflows/codeql.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
     with:
       concurrency_group: pheno-vitepress-pages
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release-drafter:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   guard:
-    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   gate:
-    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@051ecbc901964f3c7ad137b03bc62c7d3bef5d01
     permissions:
       contents: write


### PR DESCRIPTION
## **User description**
Layered PR: `codex/fix-pheno-shared-callers` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only: pinned shared CI refs and a CodeRabbit quoting tweak; no application or security logic changes, though CI behavior will follow the pinned phenoShared revision until updated.
> 
> **Overview**
> **CI callers** no longer track `@main` on `KooshaPari/phenoShared`. Every wrapper workflow (`alert-sync-issues`, deploy/VitePress, release-drafter, security-guard-hook-audit, self-merge-gate, tag-automation) now calls the same shared commit **`051ecbc901964f3c7ad137b03bc62c7d3bef5d01`**, so upstream workflow changes apply only when this repo bumps the pin.
> 
> **CodeQL** changes the reusable workflow reference from `.github/workflows/codeql.yml` to **`.github/workflows/reusable/codeql.yml`** at that same commit, aligning the caller with the shared layout.
> 
> **.coderabbit.yaml** only switches Rust `patterns_to_watch` entries for `.unwrap()` and `.expect(` from double-quoted to **single-quoted** strings (YAML escaping), with no behavior change intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0447a10af67331702704fb0f3cbc2983035458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Pin shared CI workflows and restore CodeQL checks**

### What Changed
- Several repository workflows now use the same fixed shared CI version instead of always following the latest upstream changes
- The CodeQL check now points to the correct shared workflow path, so security analysis can run from the expected location
- CodeRabbit pattern matching keeps watching Rust `.unwrap()` and `.expect()` usage after a YAML quoting fix

### Impact
`✅ More predictable CI runs`
`✅ Fewer broken workflow updates from upstream changes`
`✅ Restored CodeQL scanning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
