### PR TITLE
layer: cursor/cargo-lockfile-integrity-73e3 — fix(deps): pin phenotype-observability git dependency and up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
 [[package]]
 name = "phenotype-observability"
 version = "0.1.0"
+source = "git+https://github.com/KooshaPari/PhenoProc.git?rev=086b7f68dbf0e32e9939060c924a6c0d5187ed1f#086b7f68dbf0e32e9939060c924a6c0d5187ed1f"
 dependencies = [
  "metrics",
  "tracing",

--- a/crates/phenotype-cache-adapter/Cargo.toml
+++ b/crates/phenotype-cache-adapter/Cargo.toml
@@ -15,7 +15,7 @@ lru = "0.12"
 dashmap = "5"
 tokio = { version = "1", features = ["sync", "rt"] }
 tracing = "0.1"
-phenotype-observability = { path = "../../libs/phenotype-observability" }
+phenotype-observability = { git = "https://github.com/KooshaPari/PhenoProc.git", branch = "main" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/phenotype-cache-adapter/Cargo.toml
+++ b/crates/phenotype-cache-adapter/Cargo.toml
@@ -15,7 +15,7 @@ lru = "0.12"
 dashmap = "5"
 tokio = { version = "1", features = ["sync", "rt"] }
 tracing = "0.1"
-phenotype-observability = { git = "https://github.com/KooshaPari/PhenoProc.git", branch = "main" }
+phenotype-observability = { git = "https://github.com/KooshaPari/PhenoProc.git", rev = "086b7f68dbf0e32e9939060c924a6c0d5187ed1f" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## **User description**
Layered PR: `cursor/cargo-lockfile-integrity-73e3` → integration/consolidate (2 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency source swap only (path → pinned git); no application logic changes, with build reproducibility tied to the chosen commit.
> 
> **Overview**
> **`phenotype-cache-adapter`** no longer depends on the in-repo **`libs/phenotype-observability`** path crate. It now pulls **`phenotype-observability`** from **`https://github.com/KooshaPari/PhenoProc.git`** at revision **`086b7f68dbf0e32e9939060c924a6c0d5187ed1f`**.
> 
> **`Cargo.lock`** is updated so the **`phenotype-observability`** package entry records that git source, keeping lockfile resolution aligned with the manifest change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6dfc6a6180a7451cfa5b1356c79ba279d57b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Use a pinned git source for `phenotype-observability`**

### What Changed
- `phenotype-cache-adapter` now pulls `phenotype-observability` from its upstream Git repository instead of a local path
- The dependency is pinned to a fixed commit, so builds no longer depend on the current state of a branch or a neighboring checkout
- `Cargo.lock` is updated to match the new dependency source

### Impact
`✅ Standalone builds that do not depend on a sibling repo`
`✅ Fewer build breaks from moving dependency code`
`✅ Reproducible dependency resolution`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
