### PR TITLE
layer: deprecate-phase1-copies — fix(mcp): migrate dashboard.phenotype.dev → dashboard.koos

### DIFF
--- a/.mcp-testing.yaml
+++ b/.mcp-testing.yaml
@@ -157,7 +157,7 @@ notifications:
       - "#testing-alerts"
 
   dashboard:
-    url: "https://dashboard.phenotype.dev/testing"
+    url: "https://dashboard.kooshapari.com/testing"
     refresh_interval: "5m"
 
 # Metrics Collection

--- a/crates/phenotype-config-core/CANONICAL.md
+++ b/crates/phenotype-config-core/CANONICAL.md
@@ -1,0 +1,18 @@
+# Canonical Source Notice
+
+**This crate has been promoted to the `phenoShared` workspace.**
+
+The canonical source for `phenotype-config-core` now lives at:
+
+- Repository: https://github.com/KooshaPari/phenoShared
+- Path: https://github.com/KooshaPari/phenoShared/tree/main/crates/phenotype-config-core
+
+## Status
+
+The copy in this repository (`pheno/crates/phenotype-config-core/`) is **deprecated** and retained only for backward compatibility with existing path-based consumers. No new feature work should land here.
+
+## Migration Guidance
+
+New consumers should depend on the `phenoShared` version. Existing consumers will be migrated forward-only as part of the Phase 2 reuse rollout (see `phenoShared` PR #102 and follow-up tracking).
+
+Do **not** edit this copy for non-trivial changes — open the change against `phenoShared` instead, then re-sync.

--- a/crates/phenotype-error-core/CANONICAL.md
+++ b/crates/phenotype-error-core/CANONICAL.md
@@ -1,0 +1,18 @@
+# Canonical Source Notice
+
+**This crate has been promoted to the `phenoShared` workspace.**
+
+The canonical source for `phenotype-error-core` now lives at:
+
+- Repository: https://github.com/KooshaPari/phenoShared
+- Path: https://github.com/KooshaPari/phenoShared/tree/main/crates/phenotype-error-core
+
+## Status
+
+The copy in this repository (`pheno/crates/phenotype-error-core/`) is **deprecated** and retained only for backward compatibility with existing path-based consumers. No new feature work should land here.
+
+## Migration Guidance
+
+New consumers should depend on the `phenoShared` version. Existing consumers will be migrated forward-only as part of the Phase 2 reuse rollout (see `phenoShared` PR #102 and follow-up tracking).
+
+Do **not** edit this copy for non-trivial changes — open the change against `phenoShared` instead, then re-sync.

--- a/crates/phenotype-health/CANONICAL.md
+++ b/crates/phenotype-health/CANONICAL.md
@@ -1,0 +1,18 @@
+# Canonical Source Notice
+
+**This crate has been promoted to the `phenoShared` workspace.**
+
+The canonical source for `phenotype-health` now lives at:
+
+- Repository: https://github.com/KooshaPari/phenoShared
+- Path: https://github.com/KooshaPari/phenoShared/tree/main/crates/phenotype-health
+
+## Status
+
+The copy in this repository (`pheno/crates/phenotype-health/`) is **deprecated** and retained only for backward compatibility with existing path-based consumers. No new feature work should land here.
+
+## Migration Guidance
+
+New consumers should depend on the `phenoShared` version. Existing consumers will be migrated forward-only as part of the Phase 2 reuse rollout (see `phenoShared` PR #102 and follow-up tracking).
+
+Do **not** edit this copy for non-trivial changes — open the change against `phenoShared` instead, then re-sync.


### PR DESCRIPTION
## **User description**
Layered PR: `deprecate-phase1-copies` → integration/consolidate (2 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and config URL only; no runtime logic, auth, or dependency graph changes in this diff.
> 
> **Overview**
> **Deprecates in-repo copies** of three Rust crates that now live in `phenoShared`, and **points MCP testing reporting** at the new dashboard host.
> 
> Adds identical **`CANONICAL.md`** notices under `phenotype-config-core`, `phenotype-error-core`, and `phenotype-health`. Each states the crate is promoted to `phenoShared`, the local path is deprecated for backward compatibility only, and non-trivial changes must go to `phenoShared` with re-sync (Phase 2 / PR #102).
> 
> In **`.mcp-testing.yaml`**, changes `notifications.dashboard.url` from `https://dashboard.phenotype.dev/testing` to `https://dashboard.kooshapari.com/testing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54d703cfd9cdebb93622772cee7262d0fce3711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Move test reporting to the new dashboard and mark shared crates as deprecated copies**

### What Changed
- Test notifications now link to the new dashboard host instead of the old one
- Added clear notices to three crate folders saying their canonical source now lives in `phenoShared`
- The notices tell contributors not to make new feature changes in these local copies and to update `phenoShared` instead

### Impact
`✅ Test results open on the current dashboard`
`✅ Fewer edits made in deprecated crate copies`
`✅ Clearer guidance for crate maintenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
